### PR TITLE
adding cwd option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,10 @@ out/
 gen/
 dist/
 testData/
+bin/
+.vscode/
+.settings/
+.classpath
+.project
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.lilbaek'
-version '1.2'
+version '1.3.0'
 
 sourceCompatibility = 1.8
 repositories {
@@ -26,6 +26,7 @@ dependencies {
 patchPluginXml {
     changeNotes """      
       <ul>
+      <li><b>1.3.0</b> <br/> Support for setting a specific current working directory to use.  
       <li><b>1.2.0</b> <br/> Support for latest WebStorm.<br/> Support for setting a specific node_modules folder to use.  
       <li><b>1.1.0</b> Add plugin logo files
       <li><b>1.0.0</b> New temp file location

--- a/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeRunConfiguration.java
+++ b/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeRunConfiguration.java
@@ -1,6 +1,5 @@
 package org.lilbaek.webstorm.testcafe.run;
 
-import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.LocatableConfigurationBase;
@@ -55,6 +54,7 @@ public class TestCafeRunConfiguration extends LocatableConfigurationBase<TestCaf
         boolean liveMode;
         String browser;
         String nodeModulesLocation;
+        String cwd;
     }
 
     @Nullable
@@ -84,6 +84,9 @@ public class TestCafeRunConfiguration extends LocatableConfigurationBase<TestCaf
         if(options.nodeModulesLocation != null) {
             e.setAttribute("testcafe-node-modules", options.nodeModulesLocation);
         }
+        if(options.cwd != null) {
+            e.setAttribute("cwd", options.cwd);
+        }
         element.addContent(e);
     }
 
@@ -97,6 +100,7 @@ public class TestCafeRunConfiguration extends LocatableConfigurationBase<TestCaf
             Attribute browser = optionsElement.getAttribute("testcafe-browser");
             Attribute liveMode = optionsElement.getAttribute("testcafe-live-mode");
             Attribute nodeModulesLocation = optionsElement.getAttribute("testcafe-node-modules");
+            Attribute cwd = optionsElement.getAttribute("cwd");
             result.browser = null;
             if(browser != null) {
                 result.browser = browser.getValue();
@@ -106,6 +110,9 @@ public class TestCafeRunConfiguration extends LocatableConfigurationBase<TestCaf
             }
             if(nodeModulesLocation != null) {
                 result.nodeModulesLocation = nodeModulesLocation.getValue();
+            }
+            if(cwd != null) {
+                result.cwd = cwd.getValue();
             }
         }
         return result;

--- a/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeRunProfileState.java
+++ b/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeRunProfileState.java
@@ -43,9 +43,12 @@ import org.lilbaek.webstorm.testcafe.helpers.TestUiSessionProvider;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Collections;
 
 public class TestCafeRunProfileState implements RunProfileState, NodeLocalDebugRunProfileState {
@@ -133,8 +136,20 @@ public class TestCafeRunProfileState implements RunProfileState, NodeLocalDebugR
         Project project = myEnvironment.getProject();
         final GeneralCommandLine commandLine = new GeneralCommandLine();
         commandLine.withCharset(StandardCharsets.UTF_8);
-        String basePath = project.getBasePath();
-        commandLine.withWorkDirectory(basePath);
+
+        if(myConfiguration.options.cwd != null) {
+            Path path = Paths.get(myConfiguration.options.cwd);
+            boolean cwdExists = Files.exists(path) && Files.isDirectory(path);
+            if(cwdExists){
+                commandLine.withWorkDirectory(myConfiguration.options.cwd);
+            } else {
+                handleBadConfiguration("The current working directory " + myConfiguration.options.cwd + " is not a valid path.");
+                return commandLine;
+            }
+        } else {
+            String basePath = project.getBasePath();
+            commandLine.withWorkDirectory(basePath);
+        }
         commandLine.setExePath(interpreter.getInterpreterSystemDependentPath());
         NodeCommandLineUtil.addNodeOptionsForDebugging(commandLine, Collections.emptyList(), debugPort, true, interpreter, true);
 

--- a/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeSettingsEditor.form
+++ b/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeSettingsEditor.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.lilbaek.webstorm.testcafe.run.TestCafeSettingsEditor">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="517" height="400"/>
@@ -10,7 +10,7 @@
     <children>
       <component id="14296" class="com.intellij.ui.components.JBLabel">
         <constraints>
-          <grid row="0" column="0" row-span="3" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Browser"/>
@@ -18,13 +18,15 @@
       </component>
       <component id="3b5" class="com.intellij.openapi.ui.ComboBox" binding="browserChooser">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="15a96" class="javax.swing.JCheckBox" binding="checkBoxLiveMode">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="204" height="25"/>
+          </grid>
         </constraints>
         <properties>
           <text value="Live mode when running single test"/>
@@ -32,7 +34,7 @@
       </component>
       <component id="55e9" class="javax.swing.JLabel">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Optional node_modules folder"/>
@@ -40,6 +42,23 @@
         </properties>
       </component>
       <component id="dd460" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="nodeModulesLocation">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="55f0" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Optional current working directory"/>
+          <toolTipText value="Specify a specific config file to use"/>
+        </properties>
+      </component>
+      <component id="dd500" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="cwd">
         <constraints>
           <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>

--- a/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeSettingsEditor.java
+++ b/src/main/java/org/lilbaek/webstorm/testcafe/run/TestCafeSettingsEditor.java
@@ -28,6 +28,7 @@ public class TestCafeSettingsEditor extends SettingsEditor<TestCafeRunConfigurat
     private ComboBox<String> browserChooser;
     private JCheckBox checkBoxLiveMode;
     private TextFieldWithBrowseButton nodeModulesLocation;
+    private TextFieldWithBrowseButton cwd;
 
     TestCafeSettingsEditor(Project project) {
         browserChooser.addItem("chrome");
@@ -36,6 +37,7 @@ public class TestCafeSettingsEditor extends SettingsEditor<TestCafeRunConfigurat
         browserChooser.addItem("safari");
         browserChooser.addItem("edge");
         nodeModulesLocation.addBrowseFolderListener(new TextBrowseFolderListener(new FileChooserDescriptor(false, true, false, false, false, false)));
+        cwd.addBrowseFolderListener(new TextBrowseFolderListener(new FileChooserDescriptor(false, true, false, false, false, false)));
     }
 
     @NotNull
@@ -49,6 +51,7 @@ public class TestCafeSettingsEditor extends SettingsEditor<TestCafeRunConfigurat
         browserChooser.setSelectedItem(configuration.options.browser);
         checkBoxLiveMode.setSelected(configuration.options.liveMode);
         nodeModulesLocation.setText(configuration.options.nodeModulesLocation);
+        cwd.setText(configuration.options.cwd);
     }
 
     @Override
@@ -59,5 +62,6 @@ public class TestCafeSettingsEditor extends SettingsEditor<TestCafeRunConfigurat
         }
         configuration.options.liveMode = checkBoxLiveMode.isSelected();
         configuration.options.nodeModulesLocation = nodeModulesLocation.getText();
+        configuration.options.cwd = cwd.getText();
     }
 }


### PR DESCRIPTION
Fixes #3 

Adds a current working directory option
For a typical monorepo such as lerna, the node_modules folder needs to be at the top level, but the current working directory might need to be at a sub-package level for node's fs calls to know where to look for files.
[lerna-example.zip](https://github.com/lilbaek/webstorm-testcafe/files/3932842/lerna-example.zip)
